### PR TITLE
fix: cjs exports (#10)

### DIFF
--- a/scripts/postbuild.ts
+++ b/scripts/postbuild.ts
@@ -12,13 +12,10 @@ async function run() {
   for (const file of files) {
     // eslint-disable-next-line no-console
     console.log(chalk.cyan.inverse(' POST '), `Fix ${basename(file)}`)
-    if (file === 'index.js') {
-      // fix cjs exports
-      let code = await fs.readFile(file, 'utf8')
-      code = code.replace('exports.default =', 'module.exports =')
-      code += 'exports.default = module.exports;'
-      await fs.writeFile(file, code)
-    }
+    // fix cjs exports
+    let code = await fs.readFile(file, 'utf8')
+    code += 'if (module.exports.default) module.exports = module.exports.default;'
+    await fs.writeFile(file, code)
     // generate submodule .d.ts redirecting
     const name = basename(file, '.js')
     await fs.writeFile(`${name}.d.ts`, `export { default } from './dist/${name}'\n`)


### PR DESCRIPTION
The `file === 'index.js'` never work because `file` is an absolute path so i remove it.