### PR TITLE
fix: 'UserOptions' set to optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { createUnplugin } from 'unplugin'
 import type { Options } from './types'
 
-export default createUnplugin<Options>(options => ({
+export default createUnplugin<Options | undefined>(options => ({
   name: 'unplugin-starter',
   transformInclude(id) {
     return id.endsWith('main.ts')

--- a/src/nuxt.ts
+++ b/src/nuxt.ts
@@ -1,7 +1,7 @@
 import type { Options } from './types'
 import unplugin from '.'
 
-export default function (this: any, options: Options) {
+export default function (this: any, options?: Options) {
   // install webpack plugin
   this.extendBuild((config: any) => {
     config.plugins = config.plugins || []


### PR DESCRIPTION
We can use `Unplugin` without arguments.

https://github.com/antfu/unplugin-starter/blob/99df9a9d92aa2ccfadb34e545fd01c9ba6d20480/playground/vite.config.ts#L8
